### PR TITLE
added internationalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
@@ -29,7 +30,9 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
+        "i18next": "^24.0.2",
         "react": "^18.0.0",
+        "react-i18next": "^15.1.1",
         "react-router-dom": "^6.4.0"
       },
       "peerDependenciesMeta": {
@@ -79,9 +82,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -435,6 +438,26 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
@@ -530,32 +553,6 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.1.tgz",
-      "integrity": "sha512-P6Wg856Ou/DLpR+O0ZLneNmrv7QpqBg+hK4wE05ijbC/t349BRfMfx+UFj5Ha3fCFopIa6iSZlpdaB4agkWp2Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.17.1.tgz",
-      "integrity": "sha512-piwZDjuW2WiHr05djVdUkrG5JbjnGbtx8BXQchYCMfib/nhjzWoiScelZ+s5IJI7lecrwSxHCzW026MWBL+oJQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.17.1.tgz",
@@ -567,175 +564,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.17.1.tgz",
-      "integrity": "sha512-S7TYNQpWXB9APkxu/SLmYHezWwCoZRA9QLgrDeml+SR2A1LLPD2DBUdUlvmCF7FUpRMKvbeeWky+iizQj65Etw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.17.1.tgz",
-      "integrity": "sha512-Lq2JR5a5jsA5um2ZoLiXXEaOagnVyCpCW7xvlcqHC7y46tLwTEgUSTM3a2TfmmTMmdqv+jknUioWXlmxYxE9Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.17.1.tgz",
-      "integrity": "sha512-9BfzwyPNV0IizQoR+5HTNBGkh1KXE8BqU0DBkqMngmyFW7BfuIZyMjQ0s6igJEiPSBvT3ZcnIFohZ19OqjhDPg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.17.1.tgz",
-      "integrity": "sha512-e2uWaoxo/rtzA52OifrTSXTvJhAXb0XeRkz4CdHBK2KtxrFmuU/uNd544Ogkpu938BzEfvmWs8NZ8Axhw33FDw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.17.1.tgz",
-      "integrity": "sha512-ekggix/Bc/d/60H1Mi4YeYb/7dbal1kEDZ6sIFVAE8pUSx7PiWeEh+NWbL7bGu0X68BBIkgF3ibRJe1oFTksQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.17.1.tgz",
-      "integrity": "sha512-UGV0dUo/xCv4pkr/C8KY7XLFwBNnvladt8q+VmdKrw/3RUd3rD0TptwjisvE2TTnnlENtuY4/PZuoOYRiGp8Gw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.17.1.tgz",
-      "integrity": "sha512-gEYmYYHaehdvX46mwXrU49vD6Euf1Bxhq9pPb82cbUU9UT2NV+RSckQ5tKWOnNXZixKsy8/cPGtiUWqzPuAcXQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.17.1.tgz",
-      "integrity": "sha512-xeae5pMAxHFp6yX5vajInG2toST5lsCTrckSRUFwNgzYqnUjNBcQyqk1bXUxX5yhjWFl2Mnz3F8vQjl+2FRIcw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.17.1.tgz",
-      "integrity": "sha512-AsdnINQoDWfKpBzCPqQWxSPdAWzSgnYbrJYtn6W0H2E9It5bZss99PiLA8CgmDRfvKygt20UpZ3xkhFlIfX9zQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.17.1.tgz",
-      "integrity": "sha512-KoB4fyKXTR+wYENkIG3fFF+5G6N4GFvzYx8Jax8BR4vmddtuqSb5oQmYu2Uu067vT/Fod7gxeQYKupm8gAcMSQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.17.1.tgz",
-      "integrity": "sha512-J0d3NVNf7wBL9t4blCNat+d0PYqAx8wOoY+/9Q5cujnafbX7BmtYk3XvzkqLmFECaWvXGLuHmKj/wrILUinmQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.17.1.tgz",
-      "integrity": "sha512-xjgkWUwlq7IbgJSIxvl516FJ2iuC/7ttjsAxSPpC9kkI5iQQFHKyEN5BjbhvJ/IXIZ3yIBcW5QDlWAyrA+TFag==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.1.tgz",
-      "integrity": "sha512-0QbCkfk6cnnVKWqqlC0cUrrUMDMfu5ffvYMTUHf+qMN2uAb3MKP31LPcwiMXBNsvoFGs/kYdFOsuLmvppCopXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@trysound/sax": {
@@ -1329,6 +1157,46 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "peer": true,
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.0.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.0.2.tgz",
+      "integrity": "sha512-D88xyIGcWAKwBTAs4RSqASi8NXR/NhCVSTM4LDbdoU8qb/5dcEZjNCLDhtQBB7Epw/Cp1w2vH/3ujoTbqLSs5g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/icss-replace-symbols": {
@@ -2242,6 +2110,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.1.1.tgz",
+      "integrity": "sha512-R/Vg9wIli2P3FfeI8o1eNJUJue5LWpFsQePCHdQDmX0Co3zkr6kdT8gAseb/yGeWbNz1Txc4bKDQuZYsC0kQfw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
@@ -2676,7 +2566,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2726,6 +2616,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-router-dom": "^6.4.0"
+    "react-router-dom": "^6.4.0",
+    "i18next": "^24.0.2",
+    "react-i18next": "^15.1.1"
   },
   "peerDependenciesMeta": {
     "react-router-dom": {
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
 import terser from '@rollup/plugin-terser';
 import dts from 'rollup-plugin-dts';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
@@ -25,10 +26,11 @@ export default [{
         typescript({tsconfig: './tsconfig.json'}),
         postcss(),
         terser(),
+        json(),
     ],
 }, {
     input: 'dist/esm/types/index.d.ts',
     output: [{file: 'dist/index.d.ts', format: 'esm'}],
-    plugins: [dts()],
+    plugins: [dts(), json()],
     external: [/\.css$/],
 }];

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -1,5 +1,6 @@
 import React, {FunctionComponent} from 'react';
 import {useLoaderData, useNavigation} from 'react-router-dom';
+import {useTranslation} from "react-i18next";
 
 export interface DetailProps<D> {
     title?: string;
@@ -10,6 +11,7 @@ export interface DetailProps<D> {
 export default function Detail<D>({title, updateDocumentTitle = true, DetailComponent}: DetailProps<D>) {
     const navigation = useNavigation();
     const data = useLoaderData() as D;
+    const {t, i18n} = useTranslation();
 
     if (updateDocumentTitle) {
         document.title = title ? `Item | ${title}` : 'Item';
@@ -18,7 +20,7 @@ export default function Detail<D>({title, updateDocumentTitle = true, DetailComp
     if (navigation.state === 'loading') {
         return (
             <div className="hcContentContainer">
-                <div>Loading</div>
+                <div>{t('browser-base:loading')}</div>
             </div>
         );
     }

--- a/src/components/freeTextFacet.tsx
+++ b/src/components/freeTextFacet.tsx
@@ -1,25 +1,32 @@
 import React from 'react';
 import Facet, {DefaultFacetParams} from './facet.js';
 import useFreeTextFacet from '../hooks/useFreeTextFacet.js';
+import {useTranslation} from "react-i18next";
 
 export default function FreeTextFacet({
                                           registerFacet,
                                           unregisterFacet,
                                           setFacet,
-                                          name = 'Text search',
+                                          name = 'default_text',
                                           field = 'FREE_TEXT'
                                       }: DefaultFacetParams) {
     const [textField, setTextFacet, handleChange, handleKeyPress] =
         useFreeTextFacet(registerFacet, unregisterFacet, setFacet, name, field);
 
+    const {t, i18n} = useTranslation()
+
+    if (name == 'default_text') {
+        name = t('browser-base:textSearch')
+    }
+
     return (
         <Facet name={name}>
             <div className="hcFacetSearch">
-                <input type="text" value={textField} placeholder="Press ENTER to search"
+                <input type="text" value={textField} placeholder={t('browser-base:textSearchExplained')}
                        onChange={handleChange} onKeyUp={handleKeyPress}/>
 
                 <button type="button" name="button" onClick={setTextFacet}>
-                    Search
+                    {t('browser-base:search')}
                 </button>
             </div>
         </Facet>

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
+import {useTranslation} from "react-i18next";
 
 export interface HomeProps {
     title: string;
@@ -8,6 +9,9 @@ export interface HomeProps {
 }
 
 export default function Home({title, description, updateDocumentTitle = true}: HomeProps) {
+
+    const {t} = useTranslation()
+
     if (updateDocumentTitle) {
         document.title = title;
     }
@@ -16,7 +20,7 @@ export default function Home({title, description, updateDocumentTitle = true}: H
         <div className="hcContentContainer">
             <h2>{title}</h2>
             {description && <p>{description}</p>}
-            <Link to="search/">Browse</Link>
+            <Link to="search/">{t('browser-base:browse')}</Link>
         </div>
     );
 }

--- a/src/components/listFacet.tsx
+++ b/src/components/listFacet.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Facet, {FacetParams} from './facet.js';
 import useListFacet from '../hooks/useListFacet.js';
 import {SearchValues} from '../hooks/useSearch.js';
+import {useTranslation} from "react-i18next";
 
 interface ListFacetParams extends FacetParams {
     url: string;
@@ -28,10 +29,12 @@ export default function ListFacet({
         more, changeListLength, sendCandidate, handleChange
     ] = useListFacet(name, field, url, registerFacet, unregisterFacet, setFacet, searchValues, usePost);
 
+    const {t} = useTranslation();
+
     return (
         <Facet name={name} hidden={hidden} setHidden={setHidden}>
             {addFilter && <div className="hcFacetFilter">
-                <input type="text" placeholder="Type to filter" onChange={handleChange}/>
+                <input type="text" placeholder={t('browser-base:typeToFilter')} onChange={handleChange}/>
             </div>}
 
             <div className="hcFacetItems">
@@ -43,9 +46,9 @@ export default function ListFacet({
                     )}
 
                     {flex && (<div className="hcClickable" onClick={changeListLength}>
-                        {more ? (<div>More...</div>) : (<div>Less...</div>)}
+                        {more ? (<div>{t('browser-base:more')}...</div>) : (<div>{t('browser-base:less')}...</div>)}
                     </div>)}
-                </div>) : (<div>Loading...</div>)}
+                </div>) : (<div>{t('browser-base:loading')}...</div>)}
             </div>
         </Facet>
     );

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -10,6 +10,7 @@ import useSearch, {
 } from '../hooks/useSearch.js';
 import {getPages} from '../misc/paging.js';
 import {createCodeFromSearchObject, createParamsFromSearchObject} from '../misc/search.js';
+import {useTranslation} from "react-i18next";
 
 interface ResultList<R> {
     amount: number;
@@ -137,13 +138,16 @@ interface AmountAndPagesParams {
 }
 
 function AmountAndPages({withPaging, amount, page, pages}: AmountAndPagesParams) {
+    const {t} = useTranslation();
+
     return (
         <div className="hcResultsHeader hcMarginBottom1">
             {withPaging
                 ? amount > 9999
-                    ? <div>{amount}+ results, page {page} of {pages} pages</div>
-                    : <div>{amount} results, page {page} of {pages} pages</div>
-                : <div>{amount} items found</div>}
+                    // ? <div>{amount}+ results, page {page} of {pages} pages</div>
+                    ? <div>{t('browser-base:resultsPaged', {amount: '10000+', page: page, pages: pages})}</div>
+                    : <div>{t('browser-base:resultsPaged', {amount: amount, page: page, pages: pages})}</div>
+                : <div>{t('browser-base:results', {amount: amount})}</div>}
         </div>
     );
 }
@@ -155,15 +159,17 @@ interface SelectedFacetsParams {
 }
 
 function SelectedFacets({labeledSearchValues, resetFacets, removeFacet}: SelectedFacetsParams) {
+    const {t} = useTranslation();
+
     return (
         <div className="hcMarginBottom2">
-            <div className="hcSmallTxt hcTxtColorGreyMid">Selected facets:
-                <span className="hcFacetReset hcClickable" onClick={resetFacets}>Reset facets</span>
+            <div className="hcSmallTxt hcTxtColorGreyMid">{t('browser-base:selectedFacets')}
+                <span className="hcFacetReset hcClickable" onClick={resetFacets}>{t('browser-base:resetFacets')}</span>
             </div>
 
             {labeledSearchValues.length === 0 ? (
                 <span className="hcSelectedFacet">
-                    <span className="hcSelectedFacetType">None</span>
+                    <span className="hcSelectedFacetType">{t('browser-base:none')}</span>
                 </span>
             ) : (
                 labeledSearchValues.map((item: LabeledSearchValues) => (
@@ -190,9 +196,11 @@ interface PagingParams {
 }
 
 function Paging({page, pages, prevPage, nextPage, selectPage}: PagingParams) {
+    const {t} = useTranslation();
+
     return (
         <div className="hcPagination">
-            {page > 1 && <div className="hcClickable" onClick={prevPage}>&#8592; Previous</div>}
+            {page > 1 && <div className="hcClickable" onClick={prevPage}>&#8592; {t('browser-base:previous')}</div>}
 
             <div className="hcClickable">
                 <select className="hcPageSelector" value={page}
@@ -202,7 +210,7 @@ function Paging({page, pages, prevPage, nextPage, selectPage}: PagingParams) {
                 </select>
             </div>
 
-            {page < pages && <div className="hcClickable" onClick={nextPage}>Next &#8594;</div>}
+            {page < pages && <div className="hcClickable" onClick={nextPage}>{t('browser-base:next')} &#8594;</div>}
         </div>
     );
 }

--- a/src/components/sliderFacet.tsx
+++ b/src/components/sliderFacet.tsx
@@ -3,6 +3,7 @@ import {Root, Track, Range, Thumb} from '@radix-ui/react-slider';
 import Facet, {FacetParams} from './facet.js';
 import useSliderFacet from '../hooks/useSliderFacet.js';
 import './sliderFacet.css';
+import {useTranslation} from "react-i18next";
 
 interface SliderFacetParams extends FacetParams {
     min: number;
@@ -20,6 +21,8 @@ export default function SliderFacet({
                                     }: SliderFacetParams) {
     const [from, to, hidden, setHidden, handleChange, sendSelect] =
         useSliderFacet(name, field, registerFacet, unregisterFacet, setFacet, min, max);
+
+    const {t} = useTranslation();
 
     return (
         <Facet name={name} hidden={hidden} setHidden={setHidden}>
@@ -40,7 +43,7 @@ export default function SliderFacet({
             </Root>
 
             <div className="sliderSelect">
-                <button className="sliderSelectBtn" onClick={sendSelect}>Select</button>
+                <button className="sliderSelectBtn" onClick={sendSelect}>{t('browser-base:select')}</button>
                 [{from} - {to}]
             </div>
         </Facet>

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,11 @@ import Router from './components/router.js';
 import * as base64 from './misc/base64.js';
 import * as pagingUtils from './misc/paging.js';
 import * as searchUtils from './misc/search.js';
-import {init as initBrowserBase} from "./translations/translations";
+import {init} from "./translations/translations";
+
+function initBrowserBase(options: {lang?: string} = {lang: 'en'}) {
+    init(options.lang)
+}
 
 export {
     useSearch, useFreeTextFacet, useListFacet, useSliderFacet,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import Router from './components/router.js';
 import * as base64 from './misc/base64.js';
 import * as pagingUtils from './misc/paging.js';
 import * as searchUtils from './misc/search.js';
+import {init as initBrowserBase} from "./translations/translations";
 
 export {
     useSearch, useFreeTextFacet, useListFacet, useSliderFacet,
@@ -33,5 +34,5 @@ export {
     App, Home, PageHeader, Search, Detail, FreeTextFacet, ListFacet, SliderFacet, Router,
     base64, pagingUtils, searchUtils,
     LabeledSearchValues, SearchValues, RegisterFacet, UnregisterFacet, FacetEvent, SearchObject,
-    SearchParams, FacetsParams
+    SearchParams, FacetsParams, initBrowserBase
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,0 +1,18 @@
+{
+  "loading": "Loading",
+  "textSearchExplained": "Press ENTER to search",
+  "search": "Search",
+  "browse": "Browse",
+  "resultsPaged": "{{amount}} results found, page {{page}} of {{pages}}",
+  "results": "{{amount}} results found",
+  "selectedFacets": "Selected facets:",
+  "resetFacets": "Reset facets",
+  "none": "None",
+  "previous": "Previous",
+  "next": "Next",
+  "select": "Select",
+  "typeToFilter": "Type to filter",
+  "more": "More",
+  "less": "Less",
+  "textSearch": "Text search"
+}

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,0 +1,18 @@
+{
+  "loading": "Laden",
+  "textSearchExplained": "Druk op ENTER om te zoeken",
+  "search": "Zoek",
+  "browse": "Zoeken",
+  "resultsPaged": "{{amount}} resultaten gevonden, pagina {{page}} van {{pages}}",
+  "results": "{{amount}} resultaten gevonden",
+  "selectedFacets": "Geselecteerde facetten:",
+  "resetFacets": "Wis facetten",
+  "none": "Geen",
+  "previous": "Vorige",
+  "next": "Volgende",
+  "select": "Selecteer",
+  "typeToFilter": "Typ om te filteren",
+  "more": "Meer",
+  "less": "Minder",
+  "textSearch": "Zoeken op tekst"
+}

--- a/src/translations/translations.ts
+++ b/src/translations/translations.ts
@@ -1,0 +1,41 @@
+import i18next from "i18next";
+
+import enResources from "./en.json"
+import nlResources from "./nl.json"
+import {initReactI18next} from "react-i18next";
+
+/**
+ * Initialize the browser base. This loads translations into the i18next library if it is already
+ * in use in the application, or initializes that as well if not.
+ *
+ * @param language Optional string, only used when initializing in an environment where i18next is
+ *                 not used yet.
+ */
+export function init(language?: string) {
+
+    if (i18next.isInitialized) {
+        // Add namespaces for this library
+        if (!i18next.hasResourceBundle("en", "browserBase")) {
+            i18next.addResourceBundle("en", "browser-base", enResources);
+        }
+        if (!i18next.hasResourceBundle("nl", "browserBase")) {
+            i18next.addResourceBundle("nl", "browser-base", nlResources);
+        }
+    } else {
+        // Initialise i18n in here
+        i18next
+            .use(initReactI18next)
+            .init({
+                lng: language,
+                ns: ['browser-base'],
+                resources: {
+                    en: {
+                        'browser-base': enResources
+                    },
+                    nl: {
+                        'browser-base': nlResources
+                    },
+                }
+            })
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "emitDeclarationOnly": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
Replaced all text with i18next based translations. When the application that uses this library also uses i18next itself, this will add the translations to the 'host' instance of that so language switching is handled automatically.

Still need to figure out if (and how) initialization of the library should be done automatically when the 'parent' application doesn't use i18next. For now this adds a breaking change as the `initBrowserBase()` function needs to be called when React is started:

## When using i18next in the parent application:
Where i18next is initialized, add the following code.

```js
import {initBrowserBase} from '@knaw-huc/browser-base-react';

i18next.use(initReactI18next).init({
    lng: "en"
}).then(() => {initBrowserBase()})
```

## When you only need one language
For apps that don't use translations themselves, it's possible not to use i18next in your application but to just initialize the browser base.

```js
import {initBrowserBase} from '@knaw-huc/browser-base-react';

initBrowserBase({lang: "en"}); // or "nl"
```